### PR TITLE
Résoud l'issue #33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-/.idea/
-/COFantasy.iml

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -5504,8 +5504,14 @@ var COFantasy = COFantasy || function() {
     var optDistance = {};
     if (options.contact) optDistance.allonge = options.allonge;
     cibles = cibles.filter(function(target) {
+      // Si l'attaquant est monté, distance mesurée à partir de sa monture
+      var pseudoAttackingToken = attributeAsBool(attaquant, "monteSur") ?
+          getObj('graphic', tokenAttribute(attaquant, 'monteSur')[0].get('current')) : attackingToken;
+      // Si la cible est montée, distance mesurée vers sa monture
+      var pseudoTargetToken = attributeAsBool(target, "monteSur") ?
+          getObj('graphic', tokenAttribute(target, 'monteSur')[0].get('current')) : target.token;
       target.distance =
-        distanceCombat(attackingToken, target.token, pageId, optDistance);
+          distanceCombat(pseudoAttackingToken, pseudoTargetToken, pageId, optDistance);
       if (options.intercepter || options.interposer) return true;
       if (target.distance > portee && target.esquiveFatale === undefined) {
         if (options.aoe || options.auto) return false; //distance stricte


### PR DESCRIPTION
Permet d'émuler la présence du token du cavalier sur l'entièreté de sa monture pour faciliter la gestion des combats des persos montés.