### PR TITLE
add attack image from weapon description

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -3557,6 +3557,92 @@ var COFantasy = COFantasy || function() {
             scope.enveloppe.expression = cmd[3];
           }
           return;
+        case 'img-attack-echec-critique':
+          if (cmd.length < 1) {
+            error("Il manque une image après --img-attack-echec-critique", cmd);
+            return;
+          }
+          options.img_attack_echec_critique = cmd[1];
+          return;
+
+        case 'img-attack-echec':
+            if (cmd.length < 1) {
+              error("Il manque une image après --img-attack-echec", cmd);
+              return;
+            }
+            options.img_attack_echec = cmd[1];
+          return;
+        case 'img-attack-echec-clignotement':
+            if (cmd.length < 1) {
+              error("Il manque une image après --img-attack-echec-clignotement", cmd);
+              return;
+            }
+            options.img_attack_echec_clignotement = cmd[1];
+          return;
+        case 'img-attack-normal-touch':
+            if (cmd.length < 1) {
+              error("Il manque une image après --img-attack-normal-touch", cmd);
+              return;
+            }
+            options.img_attack_normal_touch = cmd[1];
+          return;
+        case 'img-attack-champion-succes':
+            if (cmd.length < 1) {
+              error("Il manque une image après --img-attack-champion-succes", cmd);
+              return;
+            }
+            options.img_attack_champion_succes = cmd[1];
+          return;
+        case 'img-attack-succes-critique':
+            if (cmd.length < 1) {
+              error("Il manque une image après --img-attack-succes-critique", cmd);
+              return;
+            }
+            options.img_attack_succes_critique = cmd[1];
+          return;
+          case 'sound-attack-echec-critique':
+            if (cmd.length < 1) {
+              error("Il manque le son après --sound-attack-echec-critique", cmd);
+              return;
+            }
+            options.sound_attack_echec_critique = cmd[1];
+            return;
+  
+          case 'sound-attack-echec':
+              if (cmd.length < 1) {
+                error("Il manque une sound après --sound-attack-echec", cmd);
+                return;
+              }
+              options.sound_attack_echec = cmd[1];
+            return;
+          case 'sound-attack-echec-clignotement':
+              if (cmd.length < 1) {
+                error("Il manque une sound après --sound-attack-echec-clignotement", cmd);
+                return;
+              }
+              options.sound_attack_echec_clignotement = cmd[1];
+            return;
+          case 'sound-attack-normal-touch':
+              if (cmd.length < 1) {
+                error("Il manque une sound après --sound-attack-normal-touch", cmd);
+                return;
+              }
+              options.sound_attack_normal_touch = cmd[1];
+            return;
+          case 'sound-attack-champion-succes':
+              if (cmd.length < 1) {
+                error("Il manque une sound après --sound-attack-champion-succes", cmd);
+                return;
+              }
+              options.sound_attack_champion_succes = cmd[1];
+            return;
+          case 'sound-attack-succes-critique':
+              if (cmd.length < 1) {
+                error("Il manque une sound après --sound-attack-succes-critique", cmd);
+                return;
+              }
+              options.sound_attack_succes_critique = cmd[1];
+            return;
         default:
           sendChat("COF", "Argument de !cof-attack '" + arg + "' non reconnu");
       }
@@ -6449,7 +6535,8 @@ var COFantasy = COFantasy || function() {
           }
           if (d20roll == 1 && options.chance === undefined) {
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_DANGER + "'><b>échec&nbsp;critique</b></span>";
-			      attackResult += addAttackImg("[img-attack-echec-critique]", weaponStats.divers);
+            attackResult += addAttackImg("[img-attack-echec-critique]", weaponStats.divers, options);
+            addAttackSound("[sound-attack-echec-critique]", weaponStats.divers, options);
             if (options.demiAuto) {
               target.partialSaveAuto = true;
               evt.succes = false;
@@ -6476,15 +6563,18 @@ var COFantasy = COFantasy || function() {
           } else if (paralyse || options.ouvertureMortelle || d20roll == 20 ||
             (d20roll >= target.crit && attackRoll >= defense)) {
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_SUCCESS + "'><b>réussite critique</b></span>";
-			      attackResult += addAttackImg("[img-attack-succes-critique]", weaponStats.divers);
+            attackResult += addAttackImg("[img-attack-succes-critique]", weaponStats.divers, options);
+            addAttackSound("[sound-attack-succes-critique]", weaponStats.divers, options);
             touche = true;
             critique = true;
           } else if (options.champion) {
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_SUCCESS + "'><b>succès</b></span>";
-			      attackResult += addAttackImg("[img-attack-champion-succes]", weaponStats.divers);
+            attackResult += addAttackImg("[img-attack-champion-succes]", weaponStats.divers);
+            addAttackSound("[sound-attack-champion-succes]", weaponStats.divers, options);
           } else if (attackRoll < defense && d20roll < target.crit) {
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_WARNING + "'><b>échec</b></span>";
-			      attackResult += addAttackImg("[img-attack-echec]", weaponStats.divers);
+            attackResult += addAttackImg("[img-attack-echec]", weaponStats.divers, options);
+            addAttackSound("[sound-attack-echec]", weaponStats.divers, options);
             evt.succes = false;
             if (options.demiAuto) {
               target.partialSaveAuto = true;
@@ -6492,14 +6582,16 @@ var COFantasy = COFantasy || function() {
           } else if (d20roll % 2 && attributeAsBool(target, 'clignotement')) {
             target.messages.push(target.tokName + " disparaît au moment où l'attaque aurait du l" + onGenre(target.charId, 'e', 'a') + " toucher");
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_WARNING + "'><b>échec</b></span>";
-			      attackResult += addAttackImg("[img-attack-echec-clignotement]", weaponStats.divers);
+            attackResult += addAttackImg("[img-attack-echec-clignotement]", weaponStats.divers, options);
+            addAttackSound("[sound-attack-echec-clignotement]", weaponStats.divers, options);
             target.clignotement = true;
             if (options.demiAuto) {
               target.partialSaveAuto = true;
             } else touche = false;
           } else { // Touché normal
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_SUCCESS + "'><b>succès</b></span>";
-			      attackResult += addAttackImg("[img-attack-normal-touch]", weaponStats.divers);
+            attackResult += addAttackImg("[img-attack-normal-touch]", weaponStats.divers, options);
+            addAttackSound("[sound-attack-normal-touch]", weaponStats.divers, options);
           }
           var attRollValue = buildinline(rollsAttack.inlinerolls[attRollNumber]);
           if (attSkill > 0) attRollValue += "+" + attSkill;
@@ -6604,20 +6696,91 @@ var COFantasy = COFantasy || function() {
       }); //fin de détermination de toucher des cibles
     }); // fin du jet d'attaque asynchrone
   }
+  
+  function addAttackSound(AttackParam, divers, options){
+    var sound = "";
+    if(divers.includes(AttackParam)){
+      var soundattack = divers.split(AttackParam);
+      if(soundattack.length > 2){
+        sound = soundattack[1]
+      }
+    }
 
-  function addAttackImg(AttackParam, divers){
-	var imgAttackResult = "";
+    if(sound == ""){
+      switch (AttackParam) {
+        case "[sound-attack-echec-critique]":
+          sound = options.sound_attack_echec_critique;
+          break;
+        case "[sound-attack-echec]":
+          sound = options.sound_attack_echec;
+          break;
+        case "[sound-attack-echec-clignotement]":
+          sound = options.sound_attack_echec_clignotement;
+          break;
+        case "[sound-attack-normal-touch]":
+          sound = options.sound_attack_normal_touch;
+          break;
+        case "[sound-attack-champion-succes]":
+          sound = options.sound_attack_champion_succes;
+          break;
+        case " [sound-attack-succes-critique]":
+          sound = options.sound_attack_succes_critique;
+          break;
+        default:
+          sound = "";
+      }
+    }
+  
+    if(sound != "" && sound != undefined){
+      log(sound)
+      log("!roll20AM --audio,play|"+ sound )
+      sendChat("GM","!roll20AM --audio,play|"+ sound);
+    }
+  }
+
+
+  function addAttackImg(AttackParam, divers, options){
+  var imgAttackResult = "";
+  var img = "";
 	if(divers.includes(AttackParam)){
 		var imgattack = divers.split(AttackParam);
 		if(imgattack.length > 2){
-			if(imgattack[1].toLowerCase().endsWith(".jpg") || imgattack[1].toLowerCase().endsWith(".png") || imgattack[1].toLowerCase().endsWith(".gif")){
-				var newLineimg =  '<span style="padding: 4px 0;" >  '
-				newLineimg +=   '<img src="' + imgattack[1] + '" style="width: 80%; display: block; max-width: 100%; height: auto; border-radius: 6px; margin: 0 auto;">';
-				newLineimg + '</span>';
-				imgAttackResult += newLineimg;
-			}
+      img = imgattack[1]
 		}
-	}
+  }
+  
+  if(img == "" || img == undefined){
+    switch (AttackParam) {
+      case "[img-attack-echec-critique]":
+        img = options.img_attack_echec_critique;
+        break;
+      case "[img-attack-echec]":
+        img = options.img_attack_echec
+        break;
+      case "[img-attack-echec-clignotement]":
+        img = options.img_attack_echec_clignotement
+        break;
+      case "[img-attack-normal-touch]":
+        img = options.img_attack_normal_touch
+        break;
+      case "[img-attack-champion-succes]":
+        img = options.img_attack_champion_succes
+        break;
+      case " [img-attack-succes-critique]":
+        img = options.img_attack_succes_critique
+        break;
+      default:
+        img = "";
+    }
+  }
+
+  if(img != "" && img != undefined && (img.toLowerCase().endsWith(".jpg") || img.toLowerCase().endsWith(".png") || img.toLowerCase().endsWith(".gif"))){
+    var newLineimg =  '<span style="padding: 4px 0;" >  '
+    newLineimg +=   '<img src="' + img + '" style="width: 80%; display: block; max-width: 100%; height: auto; border-radius: 6px; margin: 0 auto;">';
+    newLineimg + '</span>';
+    imgAttackResult += newLineimg;
+  }
+  
 	return imgAttackResult;
   }
 		

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -3558,13 +3558,12 @@ var COFantasy = COFantasy || function() {
           }
           return;
         case 'img-attack-echec-critique':
-          if (cmd.length < 1) {
-            error("Il manque une image après --img-attack-echec-critique", cmd);
-            return;
-          }
-          options.img_attack_echec_critique = cmd[1];
+            if (cmd.length < 1) {
+              error("Il manque une image après --img-attack-echec-critique", cmd);
+              return;
+            }
+            options.img_attack_echec_critique = cmd[1];
           return;
-
         case 'img-attack-echec':
             if (cmd.length < 1) {
               error("Il manque une image après --img-attack-echec", cmd);
@@ -3600,49 +3599,48 @@ var COFantasy = COFantasy || function() {
             }
             options.img_attack_succes_critique = cmd[1];
           return;
-          case 'sound-attack-echec-critique':
+        case 'sound-attack-echec-critique':
             if (cmd.length < 1) {
               error("Il manque le son après --sound-attack-echec-critique", cmd);
               return;
             }
             options.sound_attack_echec_critique = cmd[1];
             return;
-  
-          case 'sound-attack-echec':
-              if (cmd.length < 1) {
-                error("Il manque une sound après --sound-attack-echec", cmd);
-                return;
-              }
-              options.sound_attack_echec = cmd[1];
-            return;
-          case 'sound-attack-echec-clignotement':
-              if (cmd.length < 1) {
-                error("Il manque une sound après --sound-attack-echec-clignotement", cmd);
-                return;
-              }
-              options.sound_attack_echec_clignotement = cmd[1];
-            return;
-          case 'sound-attack-normal-touch':
-              if (cmd.length < 1) {
-                error("Il manque une sound après --sound-attack-normal-touch", cmd);
-                return;
-              }
-              options.sound_attack_normal_touch = cmd[1];
-            return;
-          case 'sound-attack-champion-succes':
-              if (cmd.length < 1) {
-                error("Il manque une sound après --sound-attack-champion-succes", cmd);
-                return;
-              }
-              options.sound_attack_champion_succes = cmd[1];
-            return;
-          case 'sound-attack-succes-critique':
-              if (cmd.length < 1) {
-                error("Il manque une sound après --sound-attack-succes-critique", cmd);
-                return;
-              }
-              options.sound_attack_succes_critique = cmd[1];
-            return;
+        case 'sound-attack-echec':
+            if (cmd.length < 1) {
+              error("Il manque une sound après --sound-attack-echec", cmd);
+              return;
+            }
+            options.sound_attack_echec = cmd[1];
+          return;
+        case 'sound-attack-echec-clignotement':
+            if (cmd.length < 1) {
+              error("Il manque une sound après --sound-attack-echec-clignotement", cmd);
+              return;
+            }
+            options.sound_attack_echec_clignotement = cmd[1];
+          return;
+        case 'sound-attack-normal-touch':
+            if (cmd.length < 1) {
+              error("Il manque une sound après --sound-attack-normal-touch", cmd);
+              return;
+            }
+            options.sound_attack_normal_touch = cmd[1];
+          return;
+        case 'sound-attack-champion-succes':
+            if (cmd.length < 1) {
+              error("Il manque une sound après --sound-attack-champion-succes", cmd);
+              return;
+            }
+            options.sound_attack_champion_succes = cmd[1];
+          return;
+        case 'sound-attack-succes-critique':
+            if (cmd.length < 1) {
+              error("Il manque une sound après --sound-attack-succes-critique", cmd);
+              return;
+            }
+            options.sound_attack_succes_critique = cmd[1];
+          return;
         default:
           sendChat("COF", "Argument de !cof-attack '" + arg + "' non reconnu");
       }

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -6449,6 +6449,7 @@ var COFantasy = COFantasy || function() {
           }
           if (d20roll == 1 && options.chance === undefined) {
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_DANGER + "'><b>échec&nbsp;critique</b></span>";
+			      attackResult += addAttackImg("[img-attack-echec-critique]", weaponStats.divers);
             if (options.demiAuto) {
               target.partialSaveAuto = true;
               evt.succes = false;
@@ -6475,12 +6476,15 @@ var COFantasy = COFantasy || function() {
           } else if (paralyse || options.ouvertureMortelle || d20roll == 20 ||
             (d20roll >= target.crit && attackRoll >= defense)) {
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_SUCCESS + "'><b>réussite critique</b></span>";
+			      attackResult += addAttackImg("[img-attack-succes-critique]", weaponStats.divers);
             touche = true;
             critique = true;
           } else if (options.champion) {
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_SUCCESS + "'><b>succès</b></span>";
+			      attackResult += addAttackImg("[img-attack-champion-succes]", weaponStats.divers);
           } else if (attackRoll < defense && d20roll < target.crit) {
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_WARNING + "'><b>échec</b></span>";
+			      attackResult += addAttackImg("[img-attack-echec]", weaponStats.divers);
             evt.succes = false;
             if (options.demiAuto) {
               target.partialSaveAuto = true;
@@ -6488,12 +6492,14 @@ var COFantasy = COFantasy || function() {
           } else if (d20roll % 2 && attributeAsBool(target, 'clignotement')) {
             target.messages.push(target.tokName + " disparaît au moment où l'attaque aurait du l" + onGenre(target.charId, 'e', 'a') + " toucher");
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_WARNING + "'><b>échec</b></span>";
+			      attackResult += addAttackImg("[img-attack-echec-clignotement]", weaponStats.divers);
             target.clignotement = true;
             if (options.demiAuto) {
               target.partialSaveAuto = true;
             } else touche = false;
           } else { // Touché normal
             attackResult = " : <span style='" + BS_LABEL + " " + BS_LABEL_SUCCESS + "'><b>succès</b></span>";
+			      attackResult += addAttackImg("[img-attack-normal-touch]", weaponStats.divers);
           }
           var attRollValue = buildinline(rollsAttack.inlinerolls[attRollNumber]);
           if (attSkill > 0) attRollValue += "+" + attSkill;
@@ -6599,6 +6605,22 @@ var COFantasy = COFantasy || function() {
     }); // fin du jet d'attaque asynchrone
   }
 
+  function addAttackImg(AttackParam, divers){
+	var imgAttackResult = "";
+	if(divers.includes(AttackParam)){
+		var imgattack = divers.split(AttackParam);
+		if(imgattack.length > 2){
+			if(imgattack[1].toLowerCase().endsWith(".jpg") || imgattack[1].toLowerCase().endsWith(".png") || imgattack[1].toLowerCase().endsWith(".gif")){
+				var newLineimg =  '<span style="padding: 4px 0;" >  '
+				newLineimg +=   '<img src="' + imgattack[1] + '" style="width: 80%; display: block; max-width: 100%; height: auto; border-radius: 6px; margin: 0 auto;">';
+				newLineimg + '</span>';
+				imgAttackResult += newLineimg;
+			}
+		}
+	}
+	return imgAttackResult;
+  }
+		
   function computeMainDmgRollExpr(attaquant, target, weaponStats, attNbDices, attDMBonus, options) {
     var attDMArme = weaponStats.attDMBonusCommun;
     if (isNaN(attDMArme) || attDMArme === 0) attDMArme = '';

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -6732,9 +6732,7 @@ var COFantasy = COFantasy || function() {
     }
   
     if(sound != "" && sound != undefined){
-      log(sound)
-      log("!roll20AM --audio,play|"+ sound )
-      sendChat("GM","!roll20AM --audio,play|"+ sound);
+      sendChat("GM","!roll20AM --audio,play,nomenu|"+ sound);
     }
   }
 

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -6736,50 +6736,49 @@ var COFantasy = COFantasy || function() {
     }
   }
 
-
   function addAttackImg(AttackParam, divers, options){
-  var imgAttackResult = "";
-  var img = "";
-	if(divers.includes(AttackParam)){
-		var imgattack = divers.split(AttackParam);
-		if(imgattack.length > 2){
-      img = imgattack[1]
-		}
-  }
-  
-  if(img == "" || img == undefined){
-    switch (AttackParam) {
-      case "[img-attack-echec-critique]":
-        img = options.img_attack_echec_critique;
-        break;
-      case "[img-attack-echec]":
-        img = options.img_attack_echec
-        break;
-      case "[img-attack-echec-clignotement]":
-        img = options.img_attack_echec_clignotement
-        break;
-      case "[img-attack-normal-touch]":
-        img = options.img_attack_normal_touch
-        break;
-      case "[img-attack-champion-succes]":
-        img = options.img_attack_champion_succes
-        break;
-      case " [img-attack-succes-critique]":
-        img = options.img_attack_succes_critique
-        break;
-      default:
-        img = "";
+    var imgAttackResult = "";
+    var img = "";
+    if(divers.includes(AttackParam)){
+      var imgattack = divers.split(AttackParam);
+      if(imgattack.length > 2){
+        img = imgattack[1]
+      }
     }
-  }
+    
+    if(img == "" || img == undefined){
+      switch (AttackParam) {
+        case "[img-attack-echec-critique]":
+          img = options.img_attack_echec_critique;
+          break;
+        case "[img-attack-echec]":
+          img = options.img_attack_echec
+          break;
+        case "[img-attack-echec-clignotement]":
+          img = options.img_attack_echec_clignotement
+          break;
+        case "[img-attack-normal-touch]":
+          img = options.img_attack_normal_touch
+          break;
+        case "[img-attack-champion-succes]":
+          img = options.img_attack_champion_succes
+          break;
+        case " [img-attack-succes-critique]":
+          img = options.img_attack_succes_critique
+          break;
+        default:
+          img = "";
+      }
+    }
 
-  if(img != "" && img != undefined && (img.toLowerCase().endsWith(".jpg") || img.toLowerCase().endsWith(".png") || img.toLowerCase().endsWith(".gif"))){
-    var newLineimg =  '<span style="padding: 4px 0;" >  '
-    newLineimg +=   '<img src="' + img + '" style="width: 80%; display: block; max-width: 100%; height: auto; border-radius: 6px; margin: 0 auto;">';
-    newLineimg + '</span>';
-    imgAttackResult += newLineimg;
-  }
-  
-	return imgAttackResult;
+    if(img != "" && img != undefined && (img.toLowerCase().endsWith(".jpg") || img.toLowerCase().endsWith(".png") || img.toLowerCase().endsWith(".gif"))){
+      var newLineimg =  '<span style="padding: 4px 0;" >  '
+      newLineimg +=   '<img src="' + img + '" style="width: 80%; display: block; max-width: 100%; height: auto; border-radius: 6px; margin: 0 auto;">';
+      newLineimg + '</span>';
+      imgAttackResult += newLineimg;
+    }
+    
+    return imgAttackResult;
   }
 		
   function computeMainDmgRollExpr(attaquant, target, weaponStats, attNbDices, attDMBonus, options) {

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -6730,7 +6730,12 @@ var COFantasy = COFantasy || function() {
     }
   
     if(sound != "" && sound != undefined){
-      sendChat("GM","!roll20AM --audio,play,nomenu|"+ sound);
+      //With Roll20 Audio Master
+      //sendChat("GM","!roll20AM --audio,play,nomenu|"+ sound);
+      _.each(findObjs({type:'jukeboxtrack',title:sound }),(track)=>{
+        var jbTrack=getObj('jukeboxtrack',track.get('_id'))
+        jbTrack.set({playing:true,softstop:false});
+     });  
     }
   }
 

--- a/doc.html
+++ b/doc.html
@@ -337,6 +337,18 @@
                   <li><code>--message <i>texte</i></code> : ajoute une ligne avec le message dans la fenêtre de l'attaque. Attention, <i>texte</i> ne doit pas contenir la séquence <code> --</code>.</li>
                   <li><code>--secret</code> : affiche les jets et résultats de l'attaque seulement aux joueurs qui contrôlent l'attaquant ou ses cibles, ainsi qu'au MJ.</li>
                   <li><code>--allonge <i>n</i></code> : ajoute <i>n</i> mètres à la portée d'une attaque au contact. L'allonge peut être un nombre à virgule et même négative.</li>
+                  <li><code>--sound-attack-echec-critique <i>son</i></code> : joue le son <i>n</i> lorque l'arme fait un echec critique</li>
+                  <li><code>--sound-attack-echec <i>son</i></code> : joue le son <i>son</i> lorque l'arme fait un echec</li>
+                  <li><code>--sound-attack-echec-clignotement <i>son</i></code> : joue le son <i>son</i> lorque l'arme fait un echec par clignotement</li>
+                  <li><code>--sound-attack-succes-critique <i>son</i></code> : joue le son <i>n</i> lorque l'arme fait un succès critique</li>
+                  <li><code>--sound-attack-normal-touch <i>son</i></code> : joue le son <i>son</i> lorque l'arme fait un succès</li>
+                  <li><code>--sound-attack-champion-succes <i>son</i></code> : joue le son <i>son</i> lorque l'arme fait un succès champion</li>
+                  <li><code>--img-attack-echec-critique <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un echec critique</li>
+                  <li><code>--img-attack-echec <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un echec</li>
+                  <li><code>--img-attack-echec-clignotement <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un echec par clignotement</li>
+                  <li><code>--img-attack-succes-critique <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un succès critique</li>
+                  <li><code>--img-attack-normal-touch <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un succès</li>
+                  <li><code>--img-attack-champion-succes <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un succès champion</li>
                 </ul>
               </div>
               <h4 class="text-secondary">Réduction des dégâts</h4>
@@ -387,6 +399,38 @@
               <h4 class="text-secondary">Sortir du combat : <code>!cof-fin-combat</code></h4>
               <div class="decalage">
                 <p>Ferme aussi le tracker de tour. Encore à mettre en macro dans la barre du MJ (macro automatiquement générée par <code>!cof-set-macros</code>). Permet de tenir compte de pleins de capacités qui durent un combat, ou utilisables une seule fois par combat,...</p>
+              </div>
+              <h4 class="text-secondary">Utilisation spéciale des images et son des armes</h4>
+              <div class="decalage">
+               <p>Les images des armes et les sons peuvent être redéfinis dans le champ détail de l'arme.</p>
+               <p>Pour ce faire vous devez ajouter les urls des images au format suivant dans la description de l'arme :</p>
+               <p><code>[<i>Type de réussite</i>] <i>url de l'image</i> [<i>Type de réussite</i>]</code></p>
+               <p>Par exemple : <code>[img-attack-echec-critique]https://media0.giphy.com/media/3og0INyCmHlNylks9O/giphy.gif[img-attack-echec-critique]</code></p>
+               <p>Les <i>types de réussite</i> que vous pouvez mettre en image sont :</p>
+               <div class="decalage">
+                  <ul>
+                    <li><code>[img-attack-echec-critique] <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un echec critique</li>
+                    <li><code>[img-attack-echec] <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un echec</li>
+                    <li><code>[img-attack-echec-clignotement] <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un echec par clignotement</li>
+                    <li><code>[img-attack-succes-critique] <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un succès critique</li>
+                    <li><code>[img-attack-normal-touch] <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un succès</li>
+                    <li><code>[img-attack-champion-succes] <i>img</i></code> : Affiche dans le chat l'image (.jpg/.png/.gif) <i>img</i> lorque l'arme fait un succès champion</li>
+                  </ul>
+                </div>
+                <p>De la même manière vous pouvez ajouter des sons :</p>
+                <p>[<i>Type de réussite</i>] <i>Nom du son dans votre jukebox</i> [<i>Type de réussite</i>]</p>
+                <div class="decalage">
+                  <ul>
+                    <li><code>[sound-attack-echec-critique] <i>son</i></code> : joue le son <i>n</i> lorque l'arme fait un echec critique</li>
+                    <li><code>[sound-attack-echec] <i>son</i></code> : joue le son <i>son</i> lorque l'arme fait un echec</li>
+                    <li><code>[sound-attack-echec-clignotement] <i>son</i></code> : joue le son <i>son</i> lorque l'arme fait un echec par clignotement</li>
+                    <li><code>[sound-attack-succes-critique] <i>son</i></code> : joue le son <i>n</i> lorque l'arme fait un succès critique</li>
+                    <li><code>[sound-attack-normal-touch] <i>son</i></code> : joue le son <i>son</i> lorque l'arme fait un succès</li>
+                    <li><code>[sound-attack-champion-succes] <i>son</i></code> : joue le son <i>son</i> lorque l'arme fait un succès champion</li>
+                  </ul>
+                </div>
+                <p>Par exemple : <code>[sound-attack-echec-critique]bang[sound-attack-echec-critique]</code></p>
+                <p>Dans cette exemple le son nomé "bang" dans votre jutbox serra joué a chaque echec critique de cette arme</p>
               </div>
               <h3 class="text-info" id="soins">2.2 Soins :</h3>
               <div class="decalage">
@@ -1493,7 +1537,7 @@
 							<p>On peut arrêter la collecte avec <code>!cof-arreter-statistiques</code>, et la mettre en pause avec <code>!cof-pause-statistiques</code>.<br />
 								Si on redémarre après une mise en pause, on reprend les statistiques comme elles étaient au moment de la pause. Si on redémarre des statistiques en court, cela remet les statistiques à zéro.
 							</p>
-						</div>
+            </div>
 					</div>
 				</div>
 		</div>


### PR DESCRIPTION
Salut,

Déjà merci beaucoup pour cette feuille de perso elle est vraiment génial.

Je te propose une petit "amélioration" de ta feuille de perso avec quelque chose que je trouve supère cool dans la feuille de dungeon et dragon 5. Se sont les gif ou images des armes qui s'affiche dans la conversation quand on les utilises.

J'ai été un peux plus loin en ajoutant une méthode (addAttackImg) qui prend en paramètre une balise :
[img-attack-echec-critique]
[img-attack-succes-critique]
[img-attack-champion-succes]
[img-attack-echec]
[img-attack-echec-clignotement]
[img-attack-normal-touch]

Du coup on peux avoir une image différant en fonction de la réussite ou non de l'action.
et pour l'utiliser il suffi dans la description de l'arme de mettre par exemple 

"
Frape avec ces petits poings

[img-attack-succes-critique]https://i0.wp.com/blog.landot-avocats.net/wp-content/uploads/2017/12/giphy4.gif[img-attack-succes-critique]
[img-attack-echec-critique]https://www.gifimili.com/gif/2018/02/minion-coup-de-poing.gif[img-attack-echec-critique]
"

Comme ça quand il y aura un Echec critique on aura l'image "minion-coup-de-poing.gif" et  quand il y aura un succès critique c'est l'image giphy4.gif qui s'affichera.


Voila, j'espère que ça te plaira :-)





