### PR TITLE
Extension de !cof-nature-nourriciere

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -9673,8 +9673,11 @@ var COFantasy = COFantasy || function() {
     });
     attrs = removeAllAttributes('elixirsACreer', evt, attrs);
     attrs = removeAllAttributes('elixir', evt, attrs);
+    //Les plantes médicinales
+    attrs = removeAllAttributes('dose_Plante médicinale', evt, attrs);
     //On pourrait diviser par 2 le nombre de baies
     //var attrsBaie = allAttributesNamed(attrs, 'dose_baie_magique');
+
   }
 
   function nouveauJour(msg) {
@@ -14852,6 +14855,11 @@ var COFantasy = COFantasy || function() {
     getSelected(msg, function(selected) {
       iterSelected(selected, function(lanceur) {
         var charId = lanceur.charId;
+        var voieDeLaSurvie = charAttributeAsInt(lanceur, 'voieDeLaSurvie', 0);
+        if (voieDeLaSurvie < 1) {
+          sendChar(charId, " ne connaît pas la Voie de la Survie");
+          return;
+        }
         var duree = rollDePlus(6);
         var output =
           "cherche des herbes. Après " + duree.roll + " heures, " +
@@ -14862,7 +14870,9 @@ var COFantasy = COFantasy || function() {
         testCaracteristique(lanceur, 'SAG', 10, {}, evt,
           function(testRes) {
             if (testRes.reussite) {
-              output += " revient avec de quoi soigner les blessés.";
+              var attrName = 'dose_Plante médicinale';
+              setTokenAttr(lanceur, attrName, voieDeLaSurvie, evt, undefined, "!cof-soin @{selected|token_id} @{selected|token_id} 1D6");
+              output += " revient avec " + voieDeLaSurvie + " plantes médicinales.";
             } else {
               output += " revient bredouille.";
             }

--- a/doc.html
+++ b/doc.html
@@ -1265,7 +1265,7 @@
                 <h4 class="text-secondary">Voie de la survie</h4>
                 <ol>
                   <li><strong>Endurant</strong> : ajouter un jet de capacité "survie", test de CON avec le bonus</li>
-                  <li><strong>Nature nourricière</strong> : pour la recherche d'herbes, on peut utiliser <code>!cof-nature-nourriciere</code></li>
+                  <li><strong>Nature nourricière</strong> : pour la recherche d'herbes, créer un attribut <code>voieDeLaSurvie</code> avec comme valeur le rang du personnage dans la voie. On peut utiliser <code>!cof-nature-nourriciere</code> pour lancer la recherche. Cela crée automatiquement les doses de plantes médicinales dans les consommables du personnage. Ces doses sont supprimées toutes les nuits.</li>
                   <li><strong>Grand pas</strong> : ajouter les compétences natation et escalade</li>
                 </ol>
                 <h4 class="text-secondary">Voie du traqueur</h4>


### PR DESCRIPTION
Réussir son jet de Nature Nourricière crée maintenant automatiquement les consommables chez le personnage. Il faut indiquer le rang de la voie dans un attribut de personnage. Comme les doses sont sensées être utilisées directement, l'attribut est simplement écrasé. Par mesure de sécurité, les doses sont supprimées par jour().