### PR TITLE
Feature/echecs critiques

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -8569,9 +8569,10 @@ var COFantasy = COFantasy || function() {
             + "qui l'aveugle temporairement."
             + bouton("!cof-effet-temp aveugleTemp 3 --save INT 12 --saveParTour CON 12", "Appliquer", evt.personnage);
       } else {
-        //TODO : Implémenter un bouton "mauvais calcul" automatique
-        return "Mauvais calcul (INT) : le personnage a une chance de toucher une autre cible sur la trajectoire" +
-            " de son tir. Déterminer la cible au hasard et relancer une attaque sur cette nouvelle cible.";
+        //TODO : Implémenter un bouton "mauvais calcul" réalisant une attaque automatique sur un des Obstacle
+        return "Mauvais calcul (INT) : le personnage a une chance de toucher une autre cible sur la trajectoire"
+            + " de son tir. Déterminer la cible au hasard et relancer une attaque sur cette nouvelle cible."
+            + bouton("!cof-jet INT 12", "Appliquer", evt.personnage);
       }
     } else if (d12roll == 6) {
       if (estCac) {

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -7588,7 +7588,7 @@ var COFantasy = COFantasy || function() {
       if (echecCritique) {
         if (stateCOF.options.affichage.val.table_crit.val)
           sendChat('COF', "[[1t[Echec-Critique-Contact]]]");
-        else sendChat('COF', suggererEchecCritique(evt, weaponStats, options.sortilege, ciblesAttaquees, attaquant));
+        else sendChat('COF', "/w GM " + suggererEchecCritique(evt, weaponStats, options.sortilege, ciblesAttaquees, attaquant));
       }
       return;
     }

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -8526,7 +8526,6 @@ var COFantasy = COFantasy || function() {
     var estMag = sortilege || weaponStats.attSkill == "@{ATKMAG}";
     var avecArme = (weaponStats.name.includes("arme") || weaponStats.divers.includes("arme"));
     var estCac = weaponStats.attSkill == "@{ATKCAC}" || weaponStats.portee == 0;
-    var estDist = weaponStats.attSkill == "@{ATKTIR}" || weaponStats.portee > 0;
 
     if(d12roll == 1) {
       if(estMag) {
@@ -8565,13 +8564,14 @@ var COFantasy = COFantasy || function() {
     } else if (d12roll == 5) {
       if (estCac) {
         return "Erreur tactique (INT) : le personnage provoque une attaque (gratuite) d’un adversaire à son contact.";
-      } else if (estDist) {
+      } else if (estMag) {
+        return "Aveuglé (INT) : le personnage ne contrôle pas sa puissance et une partie de celle-ci émet un flash "
+            + "qui l'aveugle temporairement."
+            + bouton("!cof-effet-temp aveugleTemp 3 --save INT 12 --saveParTour CON 12", "Appliquer", evt.personnage);
+      } else {
         //TODO : Implémenter un bouton "mauvais calcul" automatique
         return "Mauvais calcul (INT) : le personnage a une chance de toucher une autre cible sur la trajectoire" +
             " de son tir. Déterminer la cible au hasard et relancer une attaque sur cette nouvelle cible.";
-      } else {
-        //TODO : Nouveau statut ?
-        return "Confus(INT) : le personnage est incapable de lancer des sorts pendant 3 tours";
       }
     } else if (d12roll == 6) {
       if (estCac) {
@@ -10013,8 +10013,8 @@ var COFantasy = COFantasy || function() {
     else mObstacle = Math.round(mObstacle);
     var res = mPortee + mObstacle;
     if (mObstacle > 0) {
-      log("Obstacle" + ((mObstacle > 1) ? "s" : "") + " trouvé : " + liste_obstacles.join(', '));
-      explications.push('Obstacle' + ((mObstacle > 1) ? 's' : '') + ' sur le trajet => -' + mObstacle + ' en Attaque<br /><span style="font-size: 0.8em; color: #666;">' + liste_obstacles.join(', ') + '</span>');
+      log("Obstacle" + ((liste_obstacles.length > 1) ? "s" : "") + " trouvé : " + liste_obstacles.join(', '));
+      explications.push('Obstacle' + ((liste_obstacles.length > 1) ? 's' : '') + ' sur le trajet => -' + mObstacle + ' en Attaque<br /><span style="font-size: 0.8em; color: #666;">' + liste_obstacles.join(', ') + '</span>');
     }
     return res;
   }
@@ -22390,31 +22390,31 @@ var COFantasy = COFantasy || function() {
     },
     aveugleTemp: {
       activation: "n'y voit plus rien !",
-      actif: "", //Déjà affiché avec l'état aveugle
+      actif: "est aveuglé",
       fin: "retrouve la vue",
       prejudiciable: true
     },
     ralentiTemp: {
       activation: "est ralenti : une seule action, pas d'action limitée",
-      actif: "", //Déjà affiché avec l'état ralenti
+      actif: "est ralenti",
       fin: "n'est plus ralenti",
       prejudiciable: true
     },
     paralyseTemp: {
       activation: "est paralysé : aucune action ni déplacement possible",
-      actif: "", //Déjà affiché avec l'état ralenti
+      actif: "est paralysé",
       fin: "n'est plus paralysé",
       prejudiciable: true
     },
     etourdiTemp: {
       activation: "est étourdi : aucune action et -5 en DEF",
-      actif: "", //Déjà affiché avec l'état ralenti
+      actif: "est étourdi",
       fin: "n'est plus étourdi",
       prejudiciable: true
     },
     affaibliTemp: {
       activation: "se sent faible",
-      actif: "", //Déjà affiché avec l'état aveugle
+      actif: "est affaibli",
       fin: "se sent moins faible",
       prejudiciable: true
     },

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -8523,7 +8523,7 @@ var COFantasy = COFantasy || function() {
   function suggererEchecCritique(evt, weaponStats, sortilege, cibles, attaquant) {
     var d12roll = randomInteger(12);
 
-    var estMag = sortilege || false;
+    var estMag = sortilege || weaponStats.attSkill == "@{ATKMAG}";
     var avecArme = (weaponStats.name.includes("arme") || weaponStats.divers.includes("arme"));
     var estCac = weaponStats.attSkill == "@{ATKCAC}" || weaponStats.portee == 0;
     var estDist = weaponStats.attSkill == "@{ATKTIR}" || weaponStats.portee > 0;
@@ -8593,7 +8593,7 @@ var COFantasy = COFantasy || function() {
       return "Inconfort : Une pièce d’armure bouge et elle devient plus gênante que protectrice. Cuir : -1 en DEF "
           + "et en attaque pour le reste du combat. Maille : -2, Plaque -3. "
           + bouton("!cof-effet-combat inconfort --valeur ?{Malus ?|-1,1|-2,2|-3,3} --save CHA 12", "Appliquer", evt.personnage);
-    } else if (d12roll > 8) {
+    } else {
       return "L'attaquant s'en tire bien cette fois-ci, pas d'effet particulier";
     }
   }

--- a/doc.html
+++ b/doc.html
@@ -211,7 +211,9 @@
               <p>Malus ou bonus temporaire à une attaque : utiliser la barre 3.</p>
               <p>Le test d'attaque à distance tient compte de la portée (malus de -1 à -5 si distance entre portée et deux fois cette valeur), ainsi que des tokens sur le trajet de l'attaque. Une attaque de trop loin ne porte jamais.</p>
               <p>Utiliser une attaque fait rentrer l'attaquant en combat (et le rajoute au turn tracker).</p>
-              <p>En cas d'échec critique, le script affiche une courte suggestion pour le MJ en mal d'inspiration. Il est aussi possible d'utiliser une table plus complète (voir les options d'affichage, <code>!cof-options affichage</code>). La table utilisée (<code>Echec-Critique-Contact</code>) peut être modifiée par le MJ.</p>
+              <h4 class="text-secondary">Options pour l'attaque&nbsp;:</h4>
+              <p>En cas d'échec critique à une attaque, le script va suggérer des effets d'échec critique inspirés de <a href="">cette table suggérée par l'auteur du jeu</a>. Le script proposera même dans la plupart des cas un bouton qui automatisera les lancers de dés et l'application de l'effet, si relevant.</p>
+              <p>Il est aussi possible d'utiliser une table personnelle, non-automatisée (voir les options d'affichage, !cof-options affichage). La table utilisée (Echec-Critique-Contact) peut être modifiée par le MJ.</p>
               <h4 class="text-secondary">Options pour l'attaque&nbsp;:</h4>
               <div class="decalage">
                 <ul>


### PR DESCRIPTION
Cf. #67 

Tout y est sauf l'implémentation de l'attaque automatique en cas de "Mauvais calcul". Car ça nécessite soit un refactoring important de plusieurs méthodes pour trimbaler les obstacles identifiés dans `bonusAttaqueD()`, soit de tout recalculer à nouveau ce qui est très peu optimisé.

Comme en plus ce bouton risque de ne pas implémenter toutes les situations, je préfère push une v1 qui implémente 95% des cas.