### PR TITLE
Bugfix ITE avec ciblesSupplémentaires

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -5626,7 +5626,7 @@ var COFantasy = COFantasy || function() {
   //Evaluation récursive des if-then-else
   function evalITE(attaquant, target, deAttaque, options, evt, explications, scope, callback, inTarget, etatParent) {
     etatParent = etatParent || {};
-    if (scope.ite === undefined) {
+    if (scope.ite === undefined || scope.ite.length < 1) {
       etatParent.aTraiter = 1;
       callIfAllDone(etatParent, callback);
       return;


### PR DESCRIPTION
#148 
Bon ben finalement c'était pas si dur.
En fait avec des cibles supplémentaires on tente de reparser tous les ITE, sauf que quand ils ne sont pas dépendants de la cible (comme mon cas `deAttaque`), ils ont déjà été traités et retirés de options. Options.ite n'est alors pas "undefined", mais options.ite.length = 0 et la fonction n'appelait jamais le callback, du coup cette absence de quoique ce soit.

Très fourbe :D 