### PR TITLE
Attaques avec save & PC

### DIFF
--- a/doc.html
+++ b/doc.html
@@ -371,7 +371,7 @@
                 <h5>RD à un type de dégâts particuliers</h5>
                 <p>Pour une RD qui ne s'applique qu'à un type de dégâts particuliers, indiquer le type et la valeur séparés par <code>:</code>. Exemple : <code>feu:5</code></p>
                 <h5>RD sauf un ou plusieurs types de dégâts particuliers</h5>
-                <p>Pour une RD qui s'applique tout le temps sauf un ou plusieurs types de dégâts particuliers, indiquer la valeur puis / <code>/</code>. Exemple : <code>5/magique</code><br/>
+                <p>Pour une RD qui s'applique tout le temps sauf un ou plusieurs types de dégâts particuliers, indiquer la valeur puis <code>/</code> puis les différents types séparés par <code>_</code>. Exemple <code>/</code>. Exemple : <code>5/argent_magique</code><br/>
                 Pour une RD qui s'appliquerait à tous les types d'armes sauf une, utiliser à la place une résistance aux 2 autres types d'armes. Exemple, pour 5/tranchant, utiliser <code>percant:5,contondant:5</code>.</p>
                 <h5>RD critique</h5>
                 <p>Utiliser un attribut <code>RD_critique</code> avec comme valeur courante la résistance aux critiques. Se combine avec une éventuelle RD critique fournie par le port d'un casque.</p>

--- a/doc.html
+++ b/doc.html
@@ -370,8 +370,8 @@
                 <p>Dans le cas d'une RD simple (résistance à tous les dégâts), il suffit d'indiquer un nombre. Exemple : <code>3</code></p>
                 <h5>RD à un type de dégâts particuliers</h5>
                 <p>Pour une RD qui ne s'applique qu'à un type de dégâts particuliers, indiquer le type et la valeur séparés par <code>:</code>. Exemple : <code>feu:5</code></p>
-                <h5>RD sauf un type de dégâts particuliers</h5>
-                <p>Pour une RD qui s'applique tout le temps sauf type de dégâts particulier, indiquer la valeur et le type séparés par <code>/</code>. Exemple : <code>5/magique</code><br/>
+                <h5>RD sauf un ou plusieurs types de dégâts particuliers</h5>
+                <p>Pour une RD qui s'applique tout le temps sauf un ou plusieurs types de dégâts particuliers, indiquer la valeur puis / <code>/</code>. Exemple : <code>5/magique</code><br/>
                 Pour une RD qui s'appliquerait à tous les types d'armes sauf une, utiliser à la place une résistance aux 2 autres types d'armes. Exemple, pour 5/tranchant, utiliser <code>percant:5,contondant:5</code>.</p>
                 <h5>RD critique</h5>
                 <p>Utiliser un attribut <code>RD_critique</code> avec comme valeur courante la résistance aux critiques. Se combine avec une éventuelle RD critique fournie par le port d'un casque.</p>


### PR DESCRIPTION
Ajout de fonctionnalité, cf. #53 
Voici une implémentation partielle des PC dans les sauvegardes. Sont supportées toutes les sauvegardes **des attaques** : 
- Attaques avec états avec sauvegarde (--etat X --save X X)
- Attaques avec effets avec sauvegarde (--effet X X --save X X)
- Sauvegardes dans les ITE
- Défier la mort

L'implem se base sur la structure de "rolls" qui permet de retrouver un roll dans un évènement et y associer un bonus de PC.

Le problème, c'est qu'il reste un certain nombre de cas où save() est appelé par des évènements qui ne sont pas correctement structurés et qui, contrairement aux attaques, ne contiennent pas tout ce qu'il faut pour pouvoir "redo". J'ai marqué tous les cas restants à implémenter avec un //TODO. Pour ces cas-là, le bouton Chance ne sera pas affiché.