### PR TITLE
Options jets cachés pour les PNJ

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 ## 2.15
 ### Autres améliorations
 * Utilisation des consommables sur la fiche pour les PNJs aussi.
+* Si "Jet Secret" est configuré sur une fiche de PNJ, seul le total des jets d'attaques, de dommages, de caractéristiques et de sauvegardes sont affichés, sans les détails. Le MJ reçoit un whisper avec le détail du jet.
 
 ## 2.14
 ### Autres améliorations


### PR DESCRIPTION
Retrait du détail des calculs des jets d'attaque, de dommages, de caractéristiques pour les PNJ avec une fiche en "Jets Secrets". Le MJ reçoit un whisper avec le détail.
+ mini-fix pas de bouton chance si echec critique sur une sauvegarde

Pour moi ça implémente #104 dans quasiment tous les cas ?