### PR TITLE
Type Dégâts "mental" supporté pour les RD

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -4357,6 +4357,8 @@ var COFantasy = COFantasy || function() {
       sortilege: weaponStats.sortilege
     };
     switch (weaponStats.typeDegats) {
+      case 'mental':
+        options.attaqueMentale = true;
       case 'feu':
       case 'froid':
       case 'acide':
@@ -4370,11 +4372,7 @@ var COFantasy = COFantasy || function() {
       case 'percant':
       case 'contondant':
       case 'magique':
-
         options[weaponStats.typeDegats] = true;
-        break;
-      case 'mental':
-        options.attaqueMentale = true;
         break;
     }
     var lastEtat; //dernier de etats et effets


### PR DESCRIPTION
Petit update mais qui a son importance parce que ça permet d'opposer aux attaques avec un type "mental" une RD "mental". J'aimerais pouvoir utiliser cette option pour opposer au psionique des créatures résistantes aux attaques mentales.