### PR TITLE
Implémentation d'Absorption d'énergie

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -10151,8 +10151,14 @@ var COFantasy = COFantasy || function() {
                   if (options.vampirise || target.vampirise) {
                     soigneToken(attaquant, dmg, evt, function(soins) {
                       target.messages.push(
-                        "L'attaque soigne " + attackerTokName + " de " + soins +
-                        " PV");
+                        "L'attaque soigne " + attackerTokName + " de " + soins + " PV");
+                    });
+                  }
+                  var absorptionEnergie = attributeAsInt(attaquant, "absorptionEnergie", 0);
+                  if (absorptionEnergie > 0) {
+                    soigneToken(attaquant, absorptionEnergie, evt, function(soins) {
+                      target.messages.push(
+                        "L'attaque soigne " + attackerTokName + " de " + soins + " PV");
                     });
                   }
                   target.dmgMessage = "<b>DM :</b> ";
@@ -14083,7 +14089,6 @@ var COFantasy = COFantasy || function() {
               delete target.partialSaveAuto;
             });
           }
-          log(options);
           attack(action.playerId, action.attaquant, action.cibles, action.weaponStats, options);
           return;
         case 'jetPerso':

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 * Utilisation des consommables sur la fiche pour les PNJs aussi.
 * Si "Jet Secret" est configuré sur une fiche de PNJ, seul le total des jets d'attaques, de dommages, de caractéristiques et de sauvegardes sont affichés, sans les détails. Le MJ reçoit un whisper avec le détail du jet.
 
+### Capacités
+* Absorption d'énergie (spectre, vampire, sylvanien maudit)
+* Projeter (voie du Cogneur rang 3)
+
 ## 2.14
 ### Autres améliorations
 * Prise en compte de la chance pour les saves.

--- a/doc.html
+++ b/doc.html
@@ -1711,6 +1711,7 @@
               <h3 class="text-info" id="Capacites_diverses">4.5 Autres capacités</h3>
               <div class="decalage">
                 <ul>
+                  <li><strong>Absorption d'énergie</strong> : ajouter un attribut <code>absorptionEnergie</code> de valeur courante la valeur du soin accordé à l'attaquant à chaque fois qu'il endommage une cible.</li>
                   <li><strong>Attaque en meute</strong> : ajouter un attribut <code>attaqueEnMeute</code> de valeur courante le bonus d'attaque (2 pour un gobelin). Cela confère le bonus pour toutes les attaques de personnages avec cet attribut suivant une effectuée par un autre personnage avec cet attribut, jusqu'au prochain tour de ce personnage. Ainsi, si 2 créatures continuent d'attaquer la même cible, elles bénéficieront du bonus tout le temps, sauf la toute première attaque.</li>
                   <li><strong>Baroud d'honneur</strong> : ajouter un attribut <code>baroudHonneur</code> (=true) (Quand le personnage arrive à 0 PV, il ne meurt pas jusqu'à sa prochaine attaque, qui se fait avec un bonus de +5)</li>
                   <li><strong>Cibles multiples</strong> (nuées) : ajouter un attribut <code>ciblesMultiples</code>, de valeur <code>true</code>.</li>


### PR DESCRIPTION
Fort utile pour le S9 d'Anathazerin et diffère de --vampirise car 
1. la régénération est fixe et ne dépend pas du montant des dégâts
2. elle est applicable à toute attaque