### PR TITLE
Implémentation PC sur les tests opposés + refactoring rune d'énergie

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -3322,6 +3322,7 @@ var COFantasy = COFantasy || function() {
     var rollExpr = "[[" + de + "cs20cf" + plageECText + "]]";
     sendChat("", rollExpr, function(res) {
       var roll = options.roll || res[0].inlinerolls[0];
+      roll.token = personnage.token;
       var d20roll = roll.results.total;
       var rtext = jetCache ? d20roll + bonusCarac : buildinline(roll) + bonusText;
       var rt = {
@@ -3405,8 +3406,9 @@ var COFantasy = COFantasy || function() {
               ' ' + boutonSimple("!cof-bouton-chance " + evt.id, "Chance") +
               " (reste " + pc + " PC)";
           }
-          if (stateCOF.combat && attributeAsBool(perso, 'runeForgesort_énergie') &&
-            (caracteristique == 'FOR' || caracteristique == 'CON' || caracteristique == 'DEX')) {
+          if (stateCOF.combat && attributeAsBool(perso, 'runeForgesort_énergie')
+              && attributeAsInt(perso, 'limiteParCombat_runeForgesort_énergie', 1) > 0
+              && (caracteristique == 'FOR' || caracteristique == 'CON' || caracteristique == 'DEX')) {
             boutonsReroll += ' ' + boutonSimple("!cof-bouton-rune-energie " + evt.id, "Rune d'énergie");
           }
           if (stateCOF.combat && attributeAsBool(perso, 'petitVeinard')) {
@@ -3447,7 +3449,9 @@ var COFantasy = COFantasy || function() {
                 boutonSimple("!cof-bouton-chance " + evt.id, "Chance") +
                 " (reste " + pc + " PC)";
             }
-            if (attributeAsBool(perso, 'runeForgesort_énergie') && (caracteristique == 'FOR' || caracteristique == 'CON' || caracteristique == 'DEX')) {
+            if (attributeAsBool(perso, 'runeForgesort_énergie')
+                && attributeAsInt(perso, 'limiteParCombat_runeForgesort_énergie', 1) > 0
+                && (caracteristique == 'FOR' || caracteristique == 'CON' || caracteristique == 'DEX')) {
               msgRate += ' ' + boutonSimple("!cof-bouton-rune-energie " + evt.id, "Rune d'énergie");
             }
             if (stateCOF.combat && attributeAsBool(perso, 'petitVeinard')) {
@@ -7382,20 +7386,12 @@ var COFantasy = COFantasy || function() {
   //callback(resultat, crit, roll1, roll2):
   // resultat peut être 0, 1 ou 2 : 0 = match null, 1 le perso 1 gagne, 2 le perso 2 gagne.
   // crit peut être 1 si un des deux perso a fait une réussite critique et pas l'autre, -1 si un des personnage a fait un échec critique et pas l'autre, et 0 sinon
-  function testOppose(perso1, carac1, options1, perso2, carac2, options2, explications, evt, callback) {
+  function testOppose(rollId, perso1, carac1, options1, perso2, carac2, options2, explications, evt, callback) {
     if (carac2 === undefined) carac2 = carac1;
     var nom1 = perso1.token.get('name');
     var nom2 = perso2.token.get('name');
     jetCaracteristique(perso1, carac1, options1, evt, function(rt1, expl1) {
       jetCaracteristique(perso2, carac2, options2, evt, function(rt2, expl2) {
-        explications.push("Jet de " + carac1 + " de " + nom1 + " : " + rt1.texte);
-        expl1.forEach(function(m) {
-          explications.push(m);
-        });
-        explications.push("Jet de " + carac2 + " de " + nom2 + " : " + rt2.texte);
-        expl2.forEach(function(m) {
-          explications.push(m);
-        });
         var reussite;
         var crit = 0;
         if (rt1.total > rt2.total) reussite = 1;
@@ -7426,6 +7422,42 @@ var COFantasy = COFantasy || function() {
             diminueMalediction(perso1, evt);
             break;
         }
+        var texte1 = "Jet de " + carac1 + " de " + nom1 + " : " + rt1.texte;
+        if (options1.avecPC && reussite == 2) {
+          if ((carac1 == 'FOR' || carac1 == 'DEX' || carac1 == 'CON') &&
+              attributeAsBool(perso1, 'runeForgesort_énergie') &&
+              attributeAsInt(perso1, 'limiteParCombat_runeForgesort_énergie', 1) > 0) {
+            texte1 += boutonSimple("!cof-bouton-rune-energie " + evt.id + " " + rollId + "_roll1","Rune d'énergie");
+          }
+          if (!rt1.echecCritique && !rt2.critique) {
+          var pcPerso1 = pointsDeChance(perso1);
+          if (pcPerso1 > 0)
+            texte1 += boutonSimple("!cof-bouton-chance " +
+                evt.id + " " + rollId + "_roll1", "Chance") + " (reste " + pcPerso1 + " PC)";
+          }
+        }
+        explications.push(texte1);
+        expl1.forEach(function(m) {
+          explications.push(m);
+        });
+        var texte2 = "Jet de " + carac2 + " de " + nom2 + " : " + rt2.texte;
+        if (options2.avecPC && reussite == 1) {
+          if ((carac2 == 'FOR' || carac2 == 'DEX' || carac2 == 'CON') &&
+              attributeAsBool(perso2, 'runeForgesort_énergie') &&
+              attributeAsInt(perso2, 'limiteParCombat_runeForgesort_énergie', 1) > 0) {
+            texte2 += boutonSimple("!cof-bouton-rune-energie " + evt.id + " " + rollId + "_roll2","Rune d'énergie");
+          }
+          if (!rt2.echecCritique && !rt1.critique) {
+            var pcPerso2 = pointsDeChance(perso2);
+            if (pcPerso2 > 0)
+              texte2 += boutonSimple("!cof-bouton-chance " +
+                  evt.id + " " + rollId + "_roll2", "Chance") + " (reste " + pcPerso2 + " PC)";
+          }
+        }
+        explications.push(texte2);
+        expl2.forEach(function(m) {
+          explications.push(m);
+        });
         callback(reussite, crit, rt1.roll, rt2.roll);
       }); //Fin du jet du deuxième perso
     }); //Fin du jet du premier perso
@@ -8046,11 +8078,35 @@ var COFantasy = COFantasy || function() {
       if (options.disparition) {
         //L'immunité aux attaques sournoise est testée plus loin et ne devrait
         //pas empêcher le bonus de +5 à l'attaque.
-        testOppose(attaquant, "DEX", {
+        var rollId = 'disparition_' + cible.token.id;
+        var options1 = {
+          //TODO avecPC: true,
           bonusAttrs: ["discrétion"]
-        }, cible, "SAG", {
-          bonusAttrs: ["vigilance"]
-        }, cible.messages, evt, function(resultat) {
+        };
+        var options2 = {
+          //TODO avecPC: true,
+          bonusAttrs: ["perception"]
+        };
+        if (options.rolls) {
+          if (options.rolls[rollId + '_roll1']) {
+            options1.roll = options.rolls[rollId + '_roll1'];
+            if (options.chanceRollId && options.chanceRollId[rollId + '_roll1']) {
+              options1.bonus = options.chanceRollId[rollId + '_roll1'];
+            }
+          }
+          if (options.rolls[rollId + '_roll2']) {
+            options2.roll = options.rolls[rollId + '_roll2'];
+            if (options.chanceRollId && options.chanceRollId[rollId + '_roll2']) {
+              options2.bonus = options.chanceRollId[rollId + '_roll2'];
+            }
+          }
+        }
+        testOppose(rollId, attaquant, "DEX", options1, cible, "SAG", options2,
+            cible.messages, evt, function(resultat, crit, rt1, rt2) {
+          evt.action = evt.action || {};
+          evt.action.rolls = evt.action.rolls || {};
+          evt.action.rolls[rollId + '_roll1'] = rt1;
+          evt.action.rolls[rollId + '_roll2'] = rt2;
           if (resultat != 2) {
             cible.messages.push(attaquant.tokName + " réapparait à côté de " + cible.tokName + " et lui porte une attaque mortelle !");
             // rajout des bonus de sournoise
@@ -10606,14 +10662,29 @@ var COFantasy = COFantasy || function() {
           };
           var effetPietinement = function() {
             if ((target.pietine || target.percute) && estAussiGrandQue(attaquant, target)) {
-              var rollId = '_pietinement_' + target.token.id;
-              var options1 = {};
-              if (options.rolls && options.rolls['attaquant' + rollId])
-                options1.roll = options.rolls['attaquant' + rollId];
-              var options2 = {};
-              if (options.rolls && options.rolls['defenseur' + rollId])
-                options2.roll = options.rolls['defenseur' + rollId];
-              testOppose(target, 'FOR', options1, attaquant, 'FOR', options2, target.messages, evt, function(resultat, crit, rt1, rt2) {
+              var rollId = 'pietinement' + target.token.id;
+              var options1 = { avecPC: true };
+              var options2 = { avecPC: true };
+              if (options.rolls) {
+                if (options.rolls[rollId + '_roll1']) {
+                  options1.roll = options.rolls[rollId + '_roll1'];
+                  if (options.chanceRollId && options.chanceRollId[rollId + '_roll1']) {
+                    options1.bonus = options.chanceRollId[rollId + '_roll1'];
+                  }
+                }
+                if (options.rolls[rollId + '_roll2']) {
+                  options2.roll = options.rolls[rollId + '_roll2'];
+                  if (options.chanceRollId && options.chanceRollId[rollId + '_roll2']) {
+                    options2.bonus = options.chanceRollId[rollId + '_roll2'];
+                  }
+                }
+              }
+              testOppose(rollId, target, 'FOR', options1, attaquant, 'FOR',
+                  options2, target.messages, evt, function(resultat, crit, rt1, rt2) {
+                evt.action = evt.action || {};
+                evt.action.rolls = evt.action.rolls || {};
+                evt.action.rolls[rollId + '_roll1'] = rt1;
+                evt.action.rolls[rollId + '_roll2'] = rt2;
                 if (resultat == 2) {
                   target.messages.push(target.tokName + " est piétiné par " + attackerTokName + ", dommages doublés");
                   setState(target, 'renverse', true, evt);
@@ -10644,10 +10715,6 @@ var COFantasy = COFantasy || function() {
                   if (resultat === 0) diminueMalediction(attaquant, evt);
                   target.messages.push(target.tokName + " n'est pas piétiné.");
                 }
-                evt.actions = evt.actions || {};
-                evt.actions.rolls = evt.actions.rolls || {};
-                evt.action.rolls['attaquant' + rollId] = rt1;
-                evt.action.rolls['defenseur' + rollId] = rt2;
                 effetsAvecSave();
               });
             } else effetsAvecSave();
@@ -11067,9 +11134,17 @@ var COFantasy = COFantasy || function() {
         } else {
           smsg += " => échec";
           if (options.msgRate) smsg += options.msgRate;
-          if (options.avecPC && !tr.echecCritique) {
-            var pcTarget = pointsDeChance(target);
-            if (pcTarget > 0) smsg += "<br/>" + boutonSimple("!cof-bouton-chance " + evt.id + " " + saveId, "Chance") + " (reste " + pcTarget + " PC)";
+          if (options.avecPC) {
+            if ((carac == 'FOR' || carac == 'DEX' || carac == 'CON') &&
+                attributeAsBool(target, 'runeForgesort_énergie') &&
+                attributeAsInt(target, 'limiteParCombat_runeForgesort_énergie', 1) > 0) {
+              smsg += boutonSimple("!cof-bouton-rune-energie " + evt.id + " " + saveId,"Rune d'énergie");
+            }
+            if (!tr.echecCritique) {
+              var pcTarget = pointsDeChance(target);
+              if (pcTarget > 0) smsg += boutonSimple("!cof-bouton-chance " + evt.id + " " + saveId, "Chance")
+                  + " (reste " + pcTarget + " PC)";
+            }
           }
         }
         expliquer(smsg);
@@ -14315,6 +14390,16 @@ var COFantasy = COFantasy || function() {
         case 'save_state':
           doSaveState(action.playerId, action.perso, action.etat, action.carac, options, action.opposant, action.seuil);
           return;
+        case 'enveloppement':
+        case 'étreinte':
+          doEnveloppement(action.attaquant, action.cible, action.difficulte, action.type, action.exprDM, options);
+          return;
+        case 'libererAgrippe':
+          doLibererAgrippe(action.perso, action.agrippant, action.attrName, options);
+          return;
+        case 'provocation':
+          doProvocation(action.voleur, action.cible, options);
+          return;
         default:
           error("Evenement avec une action, mais inconnue au niveau chance. Impossible d'annuler !", evt);
           return;
@@ -14404,6 +14489,26 @@ var COFantasy = COFantasy || function() {
         return;
       }
       var perso = evtARefaire.personnage;
+      var action = evtARefaire.action;
+      if (action === undefined) {
+        error("Impossible de relancer l'action", evtARefaire);
+        return;
+      }
+      var rollId;
+      if (cmd.length > 2) {
+        var roll = action.rolls[cmd[2]];
+        if (roll === undefined) {
+          error("Erreur interne du bouton de chance : roll non identifié", cmd);
+          return;
+        }
+        if (roll.token === undefined) {
+          error("Erreur interne du bouton de chance : roll sans token", cmd);
+          return;
+        }
+        perso = persoOfId(roll.token.id, roll.token.name, roll.token.pageId);
+        rollId = cmd[2];
+        evt.rollId = rollId;
+      }
       if (perso === undefined) {
         error("Erreur interne du bouton de rune d'énergie : l'évenement n'a pas de personnage", evtARefaire);
         return;
@@ -14412,40 +14517,33 @@ var COFantasy = COFantasy || function() {
         sendPlayer(msg, "pas le droit d'utiliser ce bouton");
         return;
       }
-      var action = evtARefaire.action;
-      if (action === undefined) {
-        error("Impossible de relancer l'action", evtARefaire);
-        return;
-      }
       var carac = action.caracteristque;
       if (carac == 'SAG' || carac == 'INT' || carac == 'CHA') {
         sendChar(perso, "ne peut pas utiliser la rune d'énergie pour un test de " + carac);
         return;
       }
-      var options = action.options || {};
-      options.redo = true;
       if (!persoUtiliseRuneEnergie(perso, evt)) return;
+      var options = action.options || {};
+      options.rolls = action.rolls;
+      undoEvent(evtARefaire);
       addEvent(evt);
+      if (rollId) delete options.rolls[rollId];
+      else if (options.rolls && option.rolls.attack) delete options.rolls.attack;
       switch (evtARefaire.type) {
         case 'Attaque':
-          undoEvent(evtARefaire);
+          options.redo = true;
           if (action.cibles) {
             action.cibles.forEach(function(target) {
               delete target.partialSaveAuto;
             });
           }
-          //On garde tous les jets sauf le jet d'attaque
-          options.rolls = action.rolls;
-          if (options.rolls.attack) delete options.rolls.attack;
-          attack(action.playerId, perso, action.cibles, action.weaponStats, options);
+          attack(action.playerId, action.attaquant, action.cibles, action.weaponStats, options);
           return;
         case 'jetPerso':
-          undoEvent(evtARefaire);
-          delete options.roll; //On va le relancer
+          delete options.roll;
           jetPerso(perso, action.caracteristique, action.difficulte, action.titre, action.playerId, options);
           return;
         case 'echapperEnveloppement':
-          undoEvent(evtARefaire);
           delete options.roll;
           echapperEnveloppement({
             selected: action.selected,
@@ -14453,6 +14551,31 @@ var COFantasy = COFantasy || function() {
             playerId: action.playerId,
             options: options
           });
+          return;
+        case 'dmgDirects':
+          dmgDirects(action.playerId, action.playerName, action.cibles, action.dmg, options);
+          return;
+        case 'effetTemp':
+          effetTemporaire(action.playerId, action.cibles, action.effet, action.mEffet, action.duree, options);
+          return;
+        case 'injonctionMortelle':
+          injonctionMortelle(action.playerId, action.attaquant, action.cible, options);
+          return;
+        case 'tueurFantasmagorique':
+          tueurFantasmagorique(action.playerId, action.attaquant, action.cible, options);
+          return;
+        case 'set_state':
+          doSetState(action.cibles, action.etat, action.valeur, options);
+          return;
+        case 'save_state':
+          doSaveState(action.playerId, action.perso, action.etat, action.carac, options, action.opposant, action.seuil);
+          return;
+        case 'enveloppement':
+        case 'étreinte':
+          doEnveloppement(action.attaquant, action.cible, action.difficulte, action.type, action.exprDM, options);
+          return;
+        case 'libererAgrippe':
+          doLibererAgrippe(action.perso, action.agrippant, action.attrName, options);
           return;
         default:
           return;
@@ -16979,8 +17102,28 @@ var COFantasy = COFantasy || function() {
         perso2: opposant
       });
       var explications = [];
-      //TODO Add PC
-      testOppose(perso, carac, {}, opposant, carac, {}, explications, evt, function(resultat, crit) {
+      var rollId = 'saveState_' + perso.token.id;
+      var options1 = { avecPC: true };
+      var options2 = { avecPC: true };
+      if (options.rolls) {
+        if (options.rolls[rollId + '_roll1']) {
+          options1.roll = options.rolls[rollId + '_roll1'];
+          if (options.chanceRollId && options.chanceRollId[rollId + '_roll1']) {
+            options1.bonus = options.chanceRollId[rollId + '_roll1'];
+          }
+        }
+        if (options.rolls[rollId + '_roll2']) {
+          options2.roll = options.rolls[rollId + '_roll2'];
+          if (options.chanceRollId && options.chanceRollId[rollId + '_roll2']) {
+            options2.bonus = options.chanceRollId[rollId + '_roll2'];
+          }
+        }
+      }
+      testOppose(rollId, perso, carac, options1, opposant, carac,
+          options2, explications, evt, function(resultat, crit, rt1, rt2) {
+        evt.action.rolls = evt.action.rolls || {};
+        evt.action.rolls[rollId + '_roll1'] = rt1;
+        evt.action.rolls[rollId + '_roll2'] = rt2;
         if (resultat == 2) {
           explications.push(perso.token.get('name') + " est toujours " + stringOfEtat(etat, perso));
         } else {
@@ -17012,8 +17155,8 @@ var COFantasy = COFantasy || function() {
           sendChar(perso.charId, res.texte + " &lt; " + seuil + ", " + perso.token.get('name') + " est toujours " + stringOfEtat(etat, perso));
           if (!res.echecCritique) {
             var pcTarget = pointsDeChance(perso);
-            if (pcTarget > 0) 
-              sendChar(perso.charId, boutonSimple("!cof-bouton-chance " + 
+            if (pcTarget > 0)
+              sendChar(perso.charId, boutonSimple("!cof-bouton-chance " +
                 evt.id + " " + testId, "Chance") + " (reste " + pcTarget + " PC)");
           }
         }
@@ -22092,9 +22235,14 @@ var COFantasy = COFantasy || function() {
     addEvent(evt);
   }
 
-  function provocation(msg) {
-    var args = msg.content.split(' --');
-    var cmd = args[0].split(' ');
+  function parseProvocation(msg) {
+    var options = parseOptions(msg);
+    if (options === undefined) return;
+    var cmd = options.cmd;
+    if (cmd === undefined) {
+      error("Problème de parse options", msg.content);
+      return;
+    }
     if (cmd.length < 3) {
       error("La commande !cof-provocation requiert 2 arguments", cmd);
       return;
@@ -22109,18 +22257,50 @@ var COFantasy = COFantasy || function() {
       error("Le deuxième argument de !cof-provocation n'est pas un token valide");
       return;
     }
+    doProvocation(voleur, cible, options);
+  }
+
+  function doProvocation(voleur, cible, options) {
+    var evt = {
+      type: 'provocation',
+      action: {
+        titre: "Provocation",
+        voleur: voleur,
+        cible: cible,
+        options: options,
+      }
+    };
+    addEvent(evt);
     var nomVoleur = voleur.token.get('name');
     var nomCible = cible.token.get('name');
     var display =
-      startFramedDisplay(getPlayerIdFromMsg(msg), 'Provocation', voleur, {
-        perso2: cible
-      });
-    var evt = {
-      type: 'Provocation'
-    };
-    var jets = [];
-    testOppose(voleur, 'CHA', {}, cible, 'INT', {}, jets, evt, function(res, crit) {
-      jets.forEach(function(l) {
+        startFramedDisplay(options.playerId, 'Provocation', voleur, {
+          perso2: cible
+        });
+    var explications = [];
+    var rollId = 'provocation_' + cible.token.id;
+    var options1 = { avecPC: true };
+    var options2 = { avecPC: true };
+    if (options.rolls) {
+      if (options.rolls[rollId + '_roll1']) {
+        options1.roll = options.rolls[rollId + '_roll1'];
+        if (options.chanceRollId && options.chanceRollId[rollId + '_roll1']) {
+          options1.bonus = options.chanceRollId[rollId + '_roll1'];
+        }
+      }
+      if (options.rolls[rollId + '_roll2']) {
+        options2.roll = options.rolls[rollId + '_roll2'];
+        if (options.chanceRollId && options.chanceRollId[rollId + '_roll2']) {
+          options2.bonus = options.chanceRollId[rollId + '_roll2'];
+        }
+      }
+    }
+    testOppose(rollId, voleur, 'CHA', options1, cible, 'INT',
+        options2, explications, evt, function(res, crit, rt1, rt2) {
+      evt.action.rolls = evt.action.rolls || {};
+      evt.action.rolls[rollId + '_roll1'] = rt1;
+      evt.action.rolls[rollId + '_roll2'] = rt2;
+      explications.forEach(function(l) {
         addLineToFramedDisplay(display, l);
       });
       var reussite;
@@ -22161,7 +22341,6 @@ var COFantasy = COFantasy || function() {
           }
       }
       addLineToFramedDisplay(display, reussite);
-      addEvent(evt);
       sendChat('', endFramedDisplay(display));
     }); //Fin du test opposé
   }
@@ -25337,9 +25516,7 @@ var COFantasy = COFantasy || function() {
     });
   }
 
-  //!cof-enveloppement cubeId targetId Difficulte Attaque
-  //Attaque peut être soit label l, soit ability a, soit etreinte expr
-  function enveloppement(msg) {
+  function parseEnveloppement(msg) {
     var options = parseOptions(msg);
     if (options === undefined) return;
     var cmd = options.cmd;
@@ -25371,73 +25548,108 @@ var COFantasy = COFantasy || function() {
       difficulte = 15;
     }
     var exprDM;
-    var etreinte;
+    var type;
     switch (cmd[4]) {
       case 'label':
       case 'ability':
+        type = 'enveloppement';
+        exprDM = cmd[4] + ' ' + cmd[5];
+        break;
       case 'etreinte':
+        type = 'étreinte';
         exprDM = cmd[4] + ' ' + cmd[5];
         break;
       default:
         error("Impossible de déterminer les dégâts quand enveloppé", cmd[4]);
         return;
     }
+    doEnveloppement(cube, cible, difficulte, type, exprDM, options);
+  }
+
+  //!cof-enveloppement cubeId targetId Difficulte Attaque
+  //Attaque peut être soit label l, soit ability a, soit etreinte expr
+  function doEnveloppement(attaquant, cible, difficulte, type, exprDM, options) {
     var evt = {
-      type: 'Enveloppement'
+      type: type,
+      action: {
+        titre: "Enveloppement",
+        attaquant: attaquant,
+        cible: cible,
+        difficulte: difficulte,
+        type: type,
+        exprDM: exprDM,
+        options: options,
+      }
     };
-    if (cmd[4] == 'etreinte') {
-      evt.type = 'Étreinte';
-      etreinte = true;
-    }
+    addEvent(evt);
     //Choix de la caractéristique pour résister : FOR ou DEX
-    var caracRes = meilleureCarac('FOR', 'DEX', cible, 10 + modCarac(cube, 'force'));
-    var titre = 'Enveloppement';
-    if (etreinte) titre = 'Étreinte';
-    var display = startFramedDisplay(options.playerId, titre, cube, {
+    var caracRes = meilleureCarac('FOR', 'DEX', cible, 10 + modCarac(attaquant, 'force'));
+    var titre = (type == 'étreinte') ? 'Étreinte' : 'Enveloppement';
+    var display = startFramedDisplay(options.playerId, titre, attaquant, {
       perso2: cible
     });
     var explications = [];
-    testOppose(cube, 'FOR', {}, cible, caracRes, {}, explications, evt, function(res, crit) {
+    var rollId = 'enveloppement_' + cible.token.id;
+    var options1 = { avecPC: true };
+    var options2 = { avecPC: true };
+    if (options.rolls) {
+      if (options.rolls[rollId + '_roll1']) {
+        options1.roll = options.rolls[rollId + '_roll1'];
+        if (options.chanceRollId && options.chanceRollId[rollId + '_roll1']) {
+          options1.bonus = options.chanceRollId[rollId + '_roll1'];
+        }
+      }
+      if (options.rolls[rollId + '_roll2']) {
+        options2.roll = options.rolls[rollId + '_roll2'];
+        if (options.chanceRollId && options.chanceRollId[rollId + '_roll2']) {
+          options2.bonus = options.chanceRollId[rollId + '_roll2'];
+        }
+      }
+    }
+    testOppose(rollId, attaquant, 'FOR', options1, cible, caracRes, options2,
+        explications, evt, function(res, crit, rt1, rt2) {
+      evt.action.rolls = evt.action.rolls || {};
+      evt.action.rolls[rollId + '_roll1'] = rt1;
+      evt.action.rolls[rollId + '_roll2'] = rt2;
       var act = " a absorbé ";
       switch (res) {
         case 1:
-          if (etreinte) act = " s'est enroulé autour de ";
-          explications.push(cube.token.get('name') + act + cible.token.get('name'));
-          var cubeId = cube.token.id + ' ' + cube.token.get('name');
+          if (type == 'étreinte') act = " s'est enroulé autour de ";
+          explications.push(attaquant.token.get('name') + act + cible.token.get('name'));
+          var attaquantId = attaquant.token.id + ' ' + attaquant.token.get('name');
           var maxval = difficulte;
-          if (etreinte) maxval = 'etreinte ' + difficulte;
-          setTokenAttr(cible, 'enveloppePar', cubeId, evt, {
+          if (type == 'étreinte') maxval = 'etreinte ' + difficulte;
+          setTokenAttr(cible, 'enveloppePar', attaquantId, evt, {
             maxVal: maxval
           });
           var cibleId = cible.token.id + ' ' + cible.token.get('name');
-          cible.token.set('left', cube.token.get('left'));
-          cible.token.set('right', cube.token.get('right'));
-          toFront(cube.token);
-          setTokenAttr(cube, 'enveloppe', cibleId, evt, {
+          cible.token.set('left', attaquant.token.get('left'));
+          cible.token.set('right', attaquant.token.get('right'));
+          toFront(attaquant.token);
+          setTokenAttr(attaquant, 'enveloppe', cibleId, evt, {
             maxVal: exprDM
           });
-          if (etreinte) setState(cible, 'immobilise', true, evt);
+          if (type == 'étreinte') setState(cible, 'immobilise', true, evt);
           break;
         case 2:
           if (caracRes == 'FOR') {
-            if (etreinte) act = 'étreindre';
+            if (type == 'étreinte') act = 'étreindre';
             else act = 'absorber';
             explications.push(cible.token.get('name') + " résiste et ne se laisse pas " + act);
           } else {
-            if (etreinte) act = "l'étreinte";
+            if (type == 'étreinte') act = "l'étreinte";
             else act = "l'absorption";
             explications.push(cible.token.get('name') + " évite " + act);
           }
           break;
         default: //match null, la cible s'en sort
-          if (etreinte) act = "l'étreinte";
+          if (type == 'étreinte') act = "l'étreinte";
           else act = "l'enveloppement";
           explications.push(cible.token.get('name') + " échappe de justesse à " + act);
       }
       explications.forEach(function(e) {
         addLineToFramedDisplay(display, e);
       });
-      addEvent(evt);
       sendChat("", endFramedDisplay(display));
     });
   }
@@ -25539,8 +25751,7 @@ var COFantasy = COFantasy || function() {
     });
   }
 
-  //!cof-liberer-agrippe token_id
-  function libererAgrippe(msg) {
+  function parseLibererAgrippe(msg) {
     var options = msg.options || parseOptions(msg);
     if (options === undefined) return;
     var cmd = options.cmd;
@@ -25553,17 +25764,14 @@ var COFantasy = COFantasy || function() {
       return;
     }
     var perso = persoOfId(cmd[1], cmd[1], options.pageId);
-    perso.tokName = perso.token.get('name');
-    var attrName = 'estAgrppePar';
+    var attrName = 'estAgrippePar';
     var attr = tokenAttribute(perso, 'estAgrippePar');
-    var etreinteImmole;
     if (attr.length === 0) {
       attr = tokenAttribute(perso, 'etreinteImmolePar');
       if (attr.length === 0) {
         sendPlayer(msg, perso.tokName + " n'est pas agrippé.");
         return;
       }
-      etreinteImmole = true;
       attrName = 'etreinteImmolePar';
     }
     attr = attr[0];
@@ -25573,61 +25781,73 @@ var COFantasy = COFantasy || function() {
       attr.remove();
       return;
     }
+    doLibererAgrippe(perso, agrippant, attrName, options);
+  }
+
+  //!cof-liberer-agrippe token_id
+  function doLibererAgrippe(perso, agrippant, attrName, options) {
     var evt = {
-      type: "Tentative de se libérer"
+      type: 'libererAgrippe',
+      action: {
+        titre: "Se libérer",
+        perso: perso,
+        agrippant: agrippant,
+        attrName: attrName,
+        options: options
+      }
     };
-    var titre = "Tentative de se libérer de " + agrippant.tokName;
-    var playerId = getPlayerIdFromMsg(msg);
+    addEvent(evt);
+    var titre = "Tentative de se libérer de " + agrippant.token.get('name');
+    var playerId = options.playerId;
     var display = startFramedDisplay(playerId, titre, perso, {
       chuchote: options.secret
     });
     var explications = [];
-    if (options.chance) options.bonus = options.chance * 10;
-    if (etreinteImmole) options.dice = 20;
-    testOppose(perso, 'FOR', options, agrippant, 'FOR', {}, explications, evt, function(tr, crit) {
+    var rollId = 'libererAgrippe_' + perso.token.id;
+    var options1 = { avecPC: true };
+    var options2 = { avecPC: true };
+    if (attrName == 'etreinteImmolePar') options1.dice = 20;
+    if (options.rolls) {
+      if (options.rolls[rollId + '_roll1']) {
+        options1.roll = options.rolls[rollId + '_roll1'];
+        if (options.chanceRollId && options.chanceRollId[rollId + '_roll1']) {
+          options1.bonus = options.chanceRollId[rollId + '_roll1'];
+        }
+      }
+      if (options.rolls[rollId + '_roll2']) {
+        options2.roll = options.rolls[rollId + '_roll2'];
+        if (options.chanceRollId && options.chanceRollId[rollId + '_roll2']) {
+          options2.bonus = options.chanceRollId[rollId + '_roll2'];
+        }
+      }
+    }
+    testOppose(rollId, perso, 'FOR', options1, agrippant, 'FOR',
+        options2, explications, evt, function(tr, crit, rt1, rt2) {
+      evt.action.rolls = evt.action.rolls || {};
+      evt.action.rolls[rollId + '_roll1'] = rt1;
+      evt.action.rolls[rollId + '_roll2'] = rt2;
       explications.forEach(function(e) {
         addLineToFramedDisplay(display, e);
       });
       if (tr == 2) {
-        var msgRate = "C'est raté, " + perso.tokName + " est toujours ";
-        if (etreinteImmole)
-          msgRate += "prisonnier de l'étreinte de " + agrippant.tokName;
+        var msgRate = "C'est raté, " + perso.token.get('name') + " est toujours ";
+        if (attrName == 'etreinteImmolePar')
+          msgRate += "prisonnier de l'étreinte de " + agrippant.token.get('name');
         else msgRate += "agrippé" + eForFemale(perso) + ".";
-        evt.personnage = perso;
-        evt.action = {
-          selected: [{
-            _id: perso.token.id
-          }],
-          playerId: playerId,
-          options: options
-        };
-        evt.type = 'libererAgrippe';
-        var pc = pointsDeChance(perso);
-        if (pc > 0) {
-          options.roll = options.roll || tr.roll;
-          msgRate += ' ' +
-            boutonSimple("!cof-bouton-chance " + evt.id, "Chance") +
-            " (reste " + pc + " PC)";
-        }
-        if (attributeAsBool(perso, 'runeForgesort_énergie')) {
-          msgRate += ' ' + boutonSimple("!cof-bouton-rune-energie " + evt.id, "Rune d'énergie");
-        }
-        if (attributeAsBool(perso, 'petitVeinard')) {
-          msgRate += ' ' + boutonSimple("!cof-bouton-petit-veinard" + evt.id, "Petit veinard");
-        }
         addLineToFramedDisplay(display, msgRate);
       } else {
         if (tr === 0)
-          addLineToFramedDisplay(display, "Réussi de justesse, " + perso.tokName + " se libère.");
+          addLineToFramedDisplay(display, "Réussi de justesse, " + perso.token.get('name') + " se libère.");
         else //tr == 1
-          addLineToFramedDisplay(display, "Réussi, " + perso.tokName + " se libère.");
+          addLineToFramedDisplay(display, "Réussi, " + perso.token.get('name') + " se libère.");
         toFront(perso.token);
-        if (etreinteImmole || attr.get('max')) setState(perso, 'immobilise', false, evt);
+        var attr = tokenAttribute(perso, attrName);
+        if (attrName == 'etreinteImmolePar' || attr[0].get('max')) setState(perso, 'immobilise', false, evt);
         evt.deletedAttributes = evt.deletedAttributes || [];
-        evt.deletedAttributes.push(attr);
-        attr.remove();
+        evt.deletedAttributes.push(attr[0]);
+        attr[0].remove();
         var attrAgrippant = 'agrippe';
-        if (etreinteImmole) attrAgrippant = 'etreinteImmole';
+        if (attrName == 'etreinteImmolePar') attrAgrippant = 'etreinteImmole';
         attr = tokenAttribute(agrippant, attrAgrippant);
         attr.forEach(function(a) {
           var ca = persoOfIdName(a.get('current'));
@@ -25637,7 +25857,6 @@ var COFantasy = COFantasy || function() {
           }
         });
       }
-      addEvent(evt);
       sendChat('', endFramedDisplay(display));
     });
   }
@@ -26584,7 +26803,7 @@ var COFantasy = COFantasy || function() {
         echangeConsommable(msg);
         return;
       case "!cof-provocation":
-        provocation(msg);
+        parseProvocation(msg);
         return;
       case "!cof-en-selle":
         enSelle(msg);
@@ -26666,13 +26885,13 @@ var COFantasy = COFantasy || function() {
         lancerDefiSamourai(msg);
         return;
       case "!cof-enveloppement":
-        enveloppement(msg);
+        parseEnveloppement(msg);
         return;
       case "!cof-echapper-enveloppement":
         echapperEnveloppement(msg);
         return;
       case '!cof-liberer-agrippe':
-        libererAgrippe(msg);
+        parseLibererAgrippe(msg);
         return;
       case '!cof-animer-cadavre':
         animerCadavre(msg);


### PR DESCRIPTION
#53 
! Attention gros push !
Implémentation des PC sur tous les tests opposés déjà implémentés dans le script : enveloppement, etreinte, libererAgrippe, provocation, saveState, pietinement. Une exception, disparition, pour laquelle je crée une issue.

En plus, j'ai refactoré la rune d'énergie pour qu'elle puisse utiliser tout ce qui est fait pour les PC, du coup elle fonctionne aussi sur toutes les saves déjà implémentées et sur les tests opposés