### PR TITLE
Feature/option max rune protection

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -101,6 +101,11 @@ var COFantasy = COFantasy || function() {
               explications: "Les DMs constants d'un autre type que celui de l'arme sont aussi multipliés en cas de critique",
               val: false,
               type: 'bool'
+            },
+            max_rune_protection: {
+              explications: "Les DMs qu'une rune de protection est capable d'absorber sont limités à 10x le rang du forgesort dans la voie des runes",
+              val: false,
+              type: 'bool'
             }
           }
         },
@@ -10280,8 +10285,8 @@ var COFantasy = COFantasy || function() {
           var afterSaves = function() {
             if (saves > 0) return; //On n'a pas encore fait tous les saves
             if (options.pasDeDmg ||
-              target.utiliseRuneProtection ||
-              (additionalDmg.length === 0 && mainDmgRoll.total === 0 && attNbDices === 0)) {
+                target.utiliseRuneProtection ||
+                (additionalDmg.length === 0 && mainDmgRoll.total === 0 && attNbDices === 0)) {
               // Pas de dégâts, donc pas d'appel à dealDamage
               finCibles();
             } else {
@@ -11763,6 +11768,12 @@ var COFantasy = COFantasy || function() {
         else if (target.ignoreMoitieRD) rd = parseInt(rd / 2);
         if (target.ignoreRD) {
           rd -= target.ignoreRD; //rd peut être négatif
+        }
+        //Option Max Rune de Protection
+        if(target.utiliseRuneProtectionMax){
+          rd += target.utiliseRuneProtectionMax;
+          if(dmgTotal <= rd) expliquer("La rune de protection absorbe tous les dommages");
+          else expliquer("La rune de protection encaisse " + target.utiliseRuneProtectionMax + " dommages");
         }
         //RD PeauDePierre à prendre en compte en dernier
         if (!target.defautCuirasse && !target.ignoreTouteRD && rd < dmgTotal && attributeAsBool(target, 'peauDePierreMag')) {
@@ -22767,6 +22778,11 @@ var COFantasy = COFantasy || function() {
       msg: message,
       maxVal: forgesort.charId
     });
+    if (rune.rang === 3 && reglesOptionelles.dommages.val.max_rune_protection.val) {
+      setTokenAttr(target, "runeProtectionMax", voieDesRunes*10, evt, {
+        maxVal: forgesort.charId
+      });
+    }
   }
 
   //TODO: passer pageId en argument au lieu de prendre la page des joueurs
@@ -23179,12 +23195,16 @@ var COFantasy = COFantasy || function() {
           return;
         }
         if (!persoUtiliseRuneProtection(perso, evt)) return;
-        cible.messages.push(cible.tokName + " utilise sa Rune de Protection pour annuler les dommages");
-        cible.utiliseRuneProtection = true;
+        if (reglesOptionelles.dommages.val.max_rune_protection.val) {
+          cible.messages.push(cible.tokName + " utilise sa Rune de Protection");
+          cible.utiliseRuneProtectionMax = attributeAsInt(perso, 'runeProtectionMax', 30);
+        } else {
+          cible.messages.push(cible.tokName + " utilise sa Rune de Protection pour annuler les dommages");
+          cible.utiliseRuneProtection = true;
+        }
         removePreDmg(optionsAttaque, cible);
       }); //fin iterSelected
       attackDealDmg(action.attaquant, action.cibles, action.echecCritique, action.attackLabel, action.weaponStats, action.attackd20roll, action.display, optionsAttaque, evt, action.explications, action.pageId, action.ciblesAttaquees);
-
     }); //fin getSelected
   }
 

--- a/COFantasy.js
+++ b/COFantasy.js
@@ -104,7 +104,7 @@ var COFantasy = COFantasy || function() {
             },
             max_rune_protection: {
               explications: "Les DMs qu'une rune de protection est capable d'absorber sont limités à 10x le rang du forgesort dans la voie des runes",
-              val: false,
+              val: true,
               type: 'bool'
             }
           }

--- a/doc.html
+++ b/doc.html
@@ -1108,7 +1108,7 @@
                 <ol>
                   <li><strong>Runes de défense</strong> : ajuster la DEF sur la fiche.</li>
                   <li><strong>Runes d'énergie</strong> : La fabrication des runes de combat est gérée par la commande <code>!cof-runes</code> (il est fortement conseillé de créer une ability pour le forgesort). Le script tente de détecter quand les runes peuvent être utilisées en combat et propose un bouton (à la manière des points de chance). Lors de chaque nuit (utilisation de la commande <code>!cof-nuit</code>) toutes les runes sont retirées, mais le script va suggérer des raccourcis au forgesort pour les restaurer facilement à tous les tokens présents sur la page des joueurs (par personnage, type de rune, et aussi un bouton "Tout renouveler"). Les points de mana sont automatiquement décomptés.</li>
-                  <li><strong>Runes de protection</strong> : cf. ci-dessus.</li>
+                  <li><strong>Runes de protection</strong> : cf. ci-dessus. Le script implémente par défaut un maximum de dommages absorbés par la rune équivalent au rang du forgesort dans la voie des Runes multiplié par 10. Il est possible de désactiver cette limitation via !cof-options.</li>
                   <li><strong>Runes de puissance</strong> : cf. ci-dessus. Créer une rune de puissance vous demandera d'indiquer en plus le numéro de l'arme sur la fiche du propriétaire.</li>
                 </ol>
               </div>


### PR DESCRIPTION
#183 
Je n'ai pas prévu de migration, car par défaut la limite est à 30DM ce qui couvre déjà 99% des jets de dégâts, de deux parce que ça sera mis à jour dès la première nuit et le refresh des runes par le Forgesort.