### PR TITLE
Implem temporaire : les jets effectués lors des esquives sont conservés en cas de redo.

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -21490,7 +21490,7 @@ var COFantasy = COFantasy || function() {
       if (chance) {
         msg += '+10';
         totalEvitement += 10;
-      } else {
+      } else if (!msg || !totalEvitement) {
         var rolls = res[0];
         var attackRoll = rolls.inlinerolls[0];
         totalEvitement = attackRoll.results.total;


### PR DESCRIPTION
#53 "Ca marche".

Deux choses que je n'aime pas :
1. Rien n'est "générique", ça ne respecte pas la persistance des rolls, la partie générique PC/Petit-Veinard/Rune d'énergie, la syntaxe reDo, etc.
2. Il faut systématiquement refaire manuellement tous les choix "preDmg" effectués en cas d'undo/redo.

Grosso modo l'optimum serait de refactoriser toute cette partie pour permettre de persister toutes les informations de la partie "preDmg" (y compris les capacités utilisées, les rolls, etc) et permettre un reDo automatique de toute cette partie.