### PR TITLE
Chair à canon multiple

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -7373,7 +7373,10 @@ var COFantasy = COFantasy || function() {
         if (getState(pChair, 'mort')) return;
         var tokAttrs = charAttribute(tokCharId, 'chairACanonDe');
         var estChair = tokAttrs.find(function(a) {
-          return a.get('current') == target.tokName;
+          var chairACanonDe = a.get('current').split(",");
+          return chairACanonDe.find(function(b) {
+            return b.trim() == target.tokName;
+          });
         });
         return estChair;
       });

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -41,6 +41,7 @@
 * Meilleur support de la Parade de projectiles du moine
 * Meilleur support du Tour de force
 * Meilleur support du Pacte Sanglant 
+* Permettre à un personnage d'être la Chair à canon de plusieurs autres
 
 ### Corrections de bugs
 * Correction des RD seulement contre perçant ou tranchant ou contondant.

--- a/doc.html
+++ b/doc.html
@@ -1762,7 +1762,7 @@
                 <h4 class="text-secondary">Voie du PNJ récurrent</h4>
                 <ol>
                   <li><strong>Instinct de survie</strong> : ajouter un attribut <code>instinctDeSurvie</code> avec comme valeur le nombre de PV en-dessous duquel le PNJ gagne un bonus de DEF. les autres effets sont à faire par le MJ.</li>
-                  <li><strong>Chair à canon</strong> : ajouter un attribut <code>chairACanon</code> de valeur courante et maximale <code>1</code>. Ajouter ensuite à tous ses sous-fifres un attribut <code>chairACanonDe</code> de valeur le nom exact du token du PNJ.</li>
+                  <li><strong>Chair à canon</strong> : ajouter un attribut <code>chairACanon</code> de valeur courante et maximale <code>1</code>. Ajouter ensuite à tous ses sous-fifres un attribut <code>chairACanonDe</code> de valeur le nom exact du token du PNJ. On peut y mettre plusieurs noms séparés par des virgules.</li>
                 </ol>
                 <h4 class="text-secondary">Voie du prédateur</h4>
                 <ol>


### PR DESCRIPTION
Permettre à un personnage d'être la chair à canon de plusieurs personnages différents (pratique pour les nombreux chefs Elfes Noirs d'Anathazerïn, tous chefs de Guerriers Elfes Noirs).