### PR TITLE
Fix absorber un coup / un sort

### DIFF
--- a/COFantasy.js
+++ b/COFantasy.js
@@ -10263,14 +10263,14 @@ var COFantasy = COFantasy || function() {
                     }
                   }
                   if (options.sortilege) {
-                    if (attributeAsInt(target, 'absorberUnSort', 0) > 0 &&
+                    if (attributeAsBool(target, 'absorberUnSort', 0) &&
                       ficheAttributeAsInt(target, 'DEFBOUCLIERON', 1) == 1) {
                       options.preDmg = options.preDmg || {};
                       options.preDmg[target.token.id] = options.preDmg[target.token.id] || {};
                       options.preDmg[target.token.id].absorberUnSort = true;
                     }
                   } else {
-                    if (attributeAsInt(target, 'absorberUnCoup', 0) > 0 &&
+                    if (attributeAsBool(target, 'absorberUnCoup', 0) &&
                       ficheAttributeAsInt(target, 'DEFBOUCLIERON', 1) == 1) {
                       options.preDmg = options.preDmg || {};
                       options.preDmg[target.token.id] = options.preDmg[target.token.id] || {};


### PR DESCRIPTION
Absorber vérifiait un "int" alors qu'il a souvent "tourFinal".